### PR TITLE
Added smooth_initialization option to NaiveFourierKANLayer

### DIFF
--- a/fftKAN.py
+++ b/fftKAN.py
@@ -8,18 +8,24 @@ import numpy as np
 #Avoiding the issues of going out of grid
 
 class NaiveFourierKANLayer(th.nn.Module):
-    def __init__( self, inputdim, outdim, gridsize,addbias=True):
+    def __init__( self, inputdim, outdim, gridsize, addbias=True, smooth_initialization=False):
         super(NaiveFourierKANLayer,self).__init__()
         self.gridsize= gridsize
         self.addbias = addbias
         self.inputdim = inputdim
         self.outdim = outdim
         
+        # With smooth_initialization, fourier coefficients are attenuated by the square of their frequency.
+        # This makes KAN's scalar functions smooth at initialization.
+        # Without smooth_initialization, high gridsizes will lead to high-frequency scalar functions,
+        # with high derivatives and low correlation between similar inputs.
+        grid_norm_factor = (th.arange(gridsize) + 1)**2 if smooth_initialization else np.sqrt(gridsize)
+        
         #The normalization has been chosen so that if given inputs where each coordinate is of unit variance,
         #then each coordinates of the output is of unit variance 
         #independently of the various sizes
         self.fouriercoeffs = th.nn.Parameter( th.randn(2,outdim,inputdim,gridsize) / 
-                                             (np.sqrt(inputdim) * np.sqrt(self.gridsize) ) )
+                                                (np.sqrt(inputdim) * grid_norm_factor ) )
         if( self.addbias ):
             self.bias  = th.nn.Parameter( th.zeros(1,outdim))
 


### PR DESCRIPTION
With the default initialization scheme for `fouriercoeffs`, all frequencies draw their coefficients from the same distribution. This means that as `gridsize` becomes large, there is more and more contribution from the high frequencies, making KAN's initial scalar functions very high-frequency. In these high-frequency functions, the output values for nearby inputs are uncorrelated. This means that the initial KAN function is highly "scrambled"; and cannot "unscramble" itself during training.

For example, here is a KAN with 3 layers, 10 hidden units, and a grid size of 120 trained to encode an image using the coordinate network paradigm, for example see [SIREN](https://www.vincentsitzmann.com/siren/)

**Target image**

![image](https://github.com/GistNoesis/FourierKAN/assets/72421929/ebf81c0e-0957-4ec4-87f7-186eb0b6da18)

**With the default initialization,** 

Before training:

![image](https://github.com/GistNoesis/FourierKAN/assets/72421929/76473622-7b97-4b44-bd3d-04f718b0071d)

after training:

![image](https://github.com/GistNoesis/FourierKAN/assets/72421929/5daed291-d503-46c4-ba27-235db3f8fec9)

**With smooth initialization,**

Before training:

![image](https://github.com/GistNoesis/FourierKAN/assets/72421929/6e4621de-3a35-465a-8c54-13ffeba98c21)

after training:
![image](https://github.com/GistNoesis/FourierKAN/assets/72421929/30a23425-376d-4fe4-aef7-80a87482c529)
